### PR TITLE
Compatibility with Napari > 0.6.0

### DIFF
--- a/napari_imc/imc_controller.py
+++ b/napari_imc/imc_controller.py
@@ -200,7 +200,7 @@ class IMCController(IMCFileTreeItem):
             data,
             colormap=channel.create_colormap(),
             gamma=channel.gamma,
-            interpolation=channel.interpolation,
+            interpolation2d=channel.interpolation,
             contrast_limits=(0, np.amax(data)),  # sets contrast_limits_range
             name=(
                 f"{imc_file_acquisition.imc_file.path.name} "


### PR DESCRIPTION
Fixes the TypeError encountered, when using Napari Versions above 0.6.0. which renamed the `interpolation` keyword to `interpolation2d` when calling `viewer.add_image()`

Fixes #34 