### PR TITLE
Fix key error

### DIFF
--- a/napari_imc/imc_controller.py
+++ b/napari_imc/imc_controller.py
@@ -200,7 +200,7 @@ class IMCController(IMCFileTreeItem):
             data,
             colormap=channel.create_colormap(),
             gamma=channel.gamma,
-            interpolation=channel.interpolation,
+            interpolation2d=channel.interpolation,
             contrast_limits=(0, np.amax(data)),  # sets contrast_limits_range
             name=(
                 f"{imc_file_acquisition.imc_file.path.name} "

--- a/napari_imc/widgets/channel_controls_widget.py
+++ b/napari_imc/widgets/channel_controls_widget.py
@@ -100,16 +100,12 @@ class ChannelControlsWidget(QWidget):
                     color.alpha() / 255,
                 )
 
-        blending_combo_box_activated = self._blending_combo_box.activated[str]
-
-        @blending_combo_box_activated.connect
+        @self._blending_combo_box.textActivated.connect
         def on_blending_combo_box_activated(text: str):
             for channel in self._controller.selected_channels:
                 channel.blending = text
 
-        interpolation_combo_box_activated = self._interpolation_combo_box.activated[str]
-
-        @interpolation_combo_box_activated.connect
+        @self._interpolation_combo_box.textActivated.connect
         def on_interpolation_combo_box_activated(text: str):
             for channel in self._controller.selected_channels:
                 channel.interpolation = text


### PR DESCRIPTION
Fixes KeyError: 'there is no matching overloaded signal', that happens when using PyQt6

The `activated[str]` syntax for `QComboBox` signals is outdated and no longer supported, causing a `KeyError`.

This commit replaces the deprecated syntax with a direct connection to the `textActivated` signal